### PR TITLE
fix(security): Upgrade pac4j-jwt to 4.5.9 (CVE-2026-29000)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<org.pac4j.version>3.7.0</org.pac4j.version>
+		<org.pac4j.version>4.5.9</org.pac4j.version>
 		<jax-rs-pac4j.version>2.3.0</jax-rs-pac4j.version>
 	</properties>
 

--- a/src/main/java/com/strandls/authentication_utility/util/AuthUtil.java
+++ b/src/main/java/com/strandls/authentication_utility/util/AuthUtil.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.core.profile.jwt.JwtClaims;


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-29000**, a critical authentication bypass vulnerability in pac4j-jwt with a CVSS score of **9.1**.

### Vulnerability Details

- **CVE:** CVE-2026-29000
- **Severity:** Critical (CVSS 9.1)
- **Component:** pac4j-jwt
- **Affected Version:** 3.7.0 (current)
- **Fixed Version:** 4.5.9

### Changes

1. **pom.xml**: Updated `org.pac4j.version` property from `3.7.0` to `4.5.9`
   - This updates both `pac4j-core` and `pac4j-jwt` dependencies

2. **AuthUtil.java**: Fixed breaking API change in pac4j 4.x
   - `Pac4jConstants` class moved from `org.pac4j.core.context` to `org.pac4j.core.util`

### Testing

- Compilation verified with `mvn compile` - no errors

### Breaking Change Notes

The upgrade from pac4j 3.x to 4.x is a major version bump. The only code change required was updating the import path for `Pac4jConstants`. Downstream consumers should verify compatibility.

### Impact

This is a shared auth library used by **8 downstream repositories** in the biodiv-platform organization:
- biodiv-user
- biodiv-files
- cropcert-certification
- cropcert-entities
- cropcert-pages
- cropcert-traceability
- cropcert-users

Merging this PR will help secure all dependent services.

---

**Note:** There is an existing dependabot PR #15 for this upgrade, but it only updates pac4j-jwt individually without updating the shared version property or fixing the breaking API change. This PR provides a complete, compilable fix.